### PR TITLE
Add /UserSettings/ to .gitignore

### DIFF
--- a/Seasons Defense/.gitignore
+++ b/Seasons Defense/.gitignore
@@ -10,6 +10,9 @@
 /[Ll]ogs/
 /[Mm]emoryCaptures/
 
+# Ignore individual Unity UserSettings files
+/UserSettings/
+
 # Asset meta data should only be ignored when the corresponding asset is also ignored
 !/[Aa]ssets/**/*.meta
 


### PR DESCRIPTION
Our .gitignore was previously tracking the UserSettings folder, which could result in conflicts and constantly changing settings on our editors.