### PR TITLE
Added ammo to Towers 

### DIFF
--- a/Seasons Defense/Assets/Scenes/MiguelScene.unity
+++ b/Seasons Defense/Assets/Scenes/MiguelScene.unity
@@ -1,0 +1,311 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!29 &1
+OcclusionCullingSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_OcclusionBakeSettings:
+    smallestOccluder: 5
+    smallestHole: 0.25
+    backfaceThreshold: 100
+  m_SceneGUID: 00000000000000000000000000000000
+  m_OcclusionCullingData: {fileID: 0}
+--- !u!104 &2
+RenderSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 9
+  m_Fog: 0
+  m_FogColor: {r: 0.5, g: 0.5, b: 0.5, a: 1}
+  m_FogMode: 3
+  m_FogDensity: 0.01
+  m_LinearFogStart: 0
+  m_LinearFogEnd: 300
+  m_AmbientSkyColor: {r: 0.212, g: 0.227, b: 0.259, a: 1}
+  m_AmbientEquatorColor: {r: 0.114, g: 0.125, b: 0.133, a: 1}
+  m_AmbientGroundColor: {r: 0.047, g: 0.043, b: 0.035, a: 1}
+  m_AmbientIntensity: 1
+  m_AmbientMode: 0
+  m_SubtractiveShadowColor: {r: 0.42, g: 0.478, b: 0.627, a: 1}
+  m_SkyboxMaterial: {fileID: 10304, guid: 0000000000000000f000000000000000, type: 0}
+  m_HaloStrength: 0.5
+  m_FlareStrength: 1
+  m_FlareFadeSpeed: 3
+  m_HaloTexture: {fileID: 0}
+  m_SpotCookie: {fileID: 10001, guid: 0000000000000000e000000000000000, type: 0}
+  m_DefaultReflectionMode: 0
+  m_DefaultReflectionResolution: 128
+  m_ReflectionBounces: 1
+  m_ReflectionIntensity: 1
+  m_CustomReflection: {fileID: 0}
+  m_Sun: {fileID: 0}
+  m_IndirectSpecularColor: {r: 0, g: 0, b: 0, a: 1}
+  m_UseRadianceAmbientProbe: 0
+--- !u!157 &3
+LightmapSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 12
+  m_GIWorkflowMode: 1
+  m_GISettings:
+    serializedVersion: 2
+    m_BounceScale: 1
+    m_IndirectOutputScale: 1
+    m_AlbedoBoost: 1
+    m_EnvironmentLightingMode: 0
+    m_EnableBakedLightmaps: 1
+    m_EnableRealtimeLightmaps: 0
+  m_LightmapEditorSettings:
+    serializedVersion: 12
+    m_Resolution: 2
+    m_BakeResolution: 40
+    m_AtlasSize: 1024
+    m_AO: 0
+    m_AOMaxDistance: 1
+    m_CompAOExponent: 1
+    m_CompAOExponentDirect: 0
+    m_ExtractAmbientOcclusion: 0
+    m_Padding: 2
+    m_LightmapParameters: {fileID: 0}
+    m_LightmapsBakeMode: 1
+    m_TextureCompression: 1
+    m_FinalGather: 0
+    m_FinalGatherFiltering: 1
+    m_FinalGatherRayCount: 256
+    m_ReflectionCompression: 2
+    m_MixedBakeMode: 2
+    m_BakeBackend: 1
+    m_PVRSampling: 1
+    m_PVRDirectSampleCount: 32
+    m_PVRSampleCount: 512
+    m_PVRBounces: 2
+    m_PVREnvironmentSampleCount: 256
+    m_PVREnvironmentReferencePointCount: 2048
+    m_PVRFilteringMode: 1
+    m_PVRDenoiserTypeDirect: 1
+    m_PVRDenoiserTypeIndirect: 1
+    m_PVRDenoiserTypeAO: 1
+    m_PVRFilterTypeDirect: 0
+    m_PVRFilterTypeIndirect: 0
+    m_PVRFilterTypeAO: 0
+    m_PVREnvironmentMIS: 1
+    m_PVRCulling: 1
+    m_PVRFilteringGaussRadiusDirect: 1
+    m_PVRFilteringGaussRadiusIndirect: 5
+    m_PVRFilteringGaussRadiusAO: 2
+    m_PVRFilteringAtrousPositionSigmaDirect: 0.5
+    m_PVRFilteringAtrousPositionSigmaIndirect: 2
+    m_PVRFilteringAtrousPositionSigmaAO: 1
+    m_ExportTrainingData: 0
+    m_TrainingDataDestination: TrainingData
+    m_LightProbeSampleCountMultiplier: 4
+  m_LightingDataAsset: {fileID: 0}
+  m_LightingSettings: {fileID: 0}
+--- !u!196 &4
+NavMeshSettings:
+  serializedVersion: 2
+  m_ObjectHideFlags: 0
+  m_BuildSettings:
+    serializedVersion: 3
+    agentTypeID: 0
+    agentRadius: 0.5
+    agentHeight: 2
+    agentSlope: 45
+    agentClimb: 0.4
+    ledgeDropHeight: 0
+    maxJumpAcrossDistance: 0
+    minRegionArea: 2
+    manualCellSize: 0
+    cellSize: 0.16666667
+    manualTileSize: 0
+    tileSize: 256
+    buildHeightMesh: 0
+    maxJobWorkers: 0
+    preserveTilesOutsideBounds: 0
+    debug:
+      m_Flags: 0
+  m_NavMeshData: {fileID: 0}
+--- !u!1 &1418309785
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1418309787}
+  - component: {fileID: 1418309786}
+  m_Layer: 0
+  m_Name: Directional Light
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!108 &1418309786
+Light:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1418309785}
+  m_Enabled: 1
+  serializedVersion: 10
+  m_Type: 1
+  m_Shape: 0
+  m_Color: {r: 1, g: 0.95686275, b: 0.8392157, a: 1}
+  m_Intensity: 1
+  m_Range: 10
+  m_SpotAngle: 30
+  m_InnerSpotAngle: 21.80208
+  m_CookieSize: 10
+  m_Shadows:
+    m_Type: 2
+    m_Resolution: -1
+    m_CustomResolution: -1
+    m_Strength: 1
+    m_Bias: 0.05
+    m_NormalBias: 0.4
+    m_NearPlane: 0.2
+    m_CullingMatrixOverride:
+      e00: 1
+      e01: 0
+      e02: 0
+      e03: 0
+      e10: 0
+      e11: 1
+      e12: 0
+      e13: 0
+      e20: 0
+      e21: 0
+      e22: 1
+      e23: 0
+      e30: 0
+      e31: 0
+      e32: 0
+      e33: 1
+    m_UseCullingMatrixOverride: 0
+  m_Cookie: {fileID: 0}
+  m_DrawHalo: 0
+  m_Flare: {fileID: 0}
+  m_RenderMode: 0
+  m_CullingMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_RenderingLayerMask: 1
+  m_Lightmapping: 4
+  m_LightShadowCasterMode: 0
+  m_AreaSize: {x: 1, y: 1}
+  m_BounceIntensity: 1
+  m_ColorTemperature: 6570
+  m_UseColorTemperature: 0
+  m_BoundingSphereOverride: {x: 0, y: 0, z: 0, w: 0}
+  m_UseBoundingSphereOverride: 0
+  m_UseViewFrustumForShadowCasterCull: 1
+  m_ShadowRadius: 0
+  m_ShadowAngle: 0
+--- !u!4 &1418309787
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1418309785}
+  m_LocalRotation: {x: 0.40821788, y: -0.23456968, z: 0.10938163, w: 0.8754261}
+  m_LocalPosition: {x: 0, y: 3, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 50, y: -30, z: 0}
+--- !u!1 &1623420996
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1623420999}
+  - component: {fileID: 1623420998}
+  - component: {fileID: 1623420997}
+  m_Layer: 0
+  m_Name: Main Camera
+  m_TagString: MainCamera
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!81 &1623420997
+AudioListener:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1623420996}
+  m_Enabled: 1
+--- !u!20 &1623420998
+Camera:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1623420996}
+  m_Enabled: 1
+  serializedVersion: 2
+  m_ClearFlags: 2
+  m_BackGroundColor: {r: 0.19913672, g: 0.21341375, b: 0.23584908, a: 0}
+  m_projectionMatrixMode: 1
+  m_GateFitMode: 2
+  m_FOVAxisMode: 0
+  m_Iso: 200
+  m_ShutterSpeed: 0.005
+  m_Aperture: 16
+  m_FocusDistance: 10
+  m_FocalLength: 50
+  m_BladeCount: 5
+  m_Curvature: {x: 2, y: 11}
+  m_BarrelClipping: 0.25
+  m_Anamorphism: 0
+  m_SensorSize: {x: 36, y: 24}
+  m_LensShift: {x: 0, y: 0}
+  m_NormalizedViewPortRect:
+    serializedVersion: 2
+    x: 0
+    y: 0
+    width: 1
+    height: 1
+  near clip plane: 0.3
+  far clip plane: 1000
+  field of view: 60
+  orthographic: 1
+  orthographic size: 10
+  m_Depth: -1
+  m_CullingMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_RenderingPath: -1
+  m_TargetTexture: {fileID: 0}
+  m_TargetDisplay: 0
+  m_TargetEye: 3
+  m_HDR: 1
+  m_AllowMSAA: 1
+  m_AllowDynamicResolution: 0
+  m_ForceIntoRT: 0
+  m_OcclusionCulling: 1
+  m_StereoConvergence: 10
+  m_StereoSeparation: 0.022
+--- !u!4 &1623420999
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1623420996}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 1, z: -10}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}

--- a/Seasons Defense/Assets/Scenes/MiguelScene.unity.meta
+++ b/Seasons Defense/Assets/Scenes/MiguelScene.unity.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 45a7e6b77ae2d3f429102ce6ef30ca7f
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Seasons Defense/Assets/Scripts/Missile.cs
+++ b/Seasons Defense/Assets/Scripts/Missile.cs
@@ -27,7 +27,7 @@ public class Missile : MonoBehaviour
     private void Explode()
     {
         // Creates an explosion object at missile's location
-        Instantiate(explosionPrefab);
+        Instantiate(explosionPrefab, transform.position, Quaternion.identity);
 
         // Missile is no longer needed
         Destroy(gameObject);

--- a/Seasons Defense/Assets/Scripts/Missile.cs
+++ b/Seasons Defense/Assets/Scripts/Missile.cs
@@ -13,7 +13,6 @@ public class Missile : MonoBehaviour
     private void Start()
     {
         transform.LookAt(target);
-        
     }
     private void Update()
     {

--- a/Seasons Defense/Assets/Scripts/Tower.cs
+++ b/Seasons Defense/Assets/Scripts/Tower.cs
@@ -4,14 +4,20 @@ public class Tower : MonoBehaviour
 {
     public GameObject missilePrefab;
     public float offset;
+    
+    private int missileCount = 5;
     private Vector3 _towerPosition;
-
+    
     private void Start()
     {
         _towerPosition = new Vector3(transform.position.x, transform.position.y + offset, 0);
     }
 
     public void Fire() {
+
+        if (missileCount == 0) return;
+
+        missileCount--;
 
         Vector3 mousePosition = new Vector3(Input.mousePosition.x, Input.mousePosition.y, transform.position.z);
         Vector3 worldPosition = Camera.main.ScreenToWorldPoint(mousePosition);
@@ -25,5 +31,15 @@ public class Tower : MonoBehaviour
         {
             missile.target = worldPosition;
         }
+    }
+
+    public int getMissileCount()
+    {
+        return this.missileCount;
+    }
+
+    public void ReloadTower(int amount)
+    {
+        this.missileCount += amount;
     }
 }

--- a/Seasons Defense/Assets/Scripts/Tower.cs
+++ b/Seasons Defense/Assets/Scripts/Tower.cs
@@ -15,6 +15,7 @@ public class Tower : MonoBehaviour
 
     public void Fire() {
 
+        // a tower will only fire if their missile count is greater than 0
         if (missileCount == 0) return;
 
         missileCount--;
@@ -33,6 +34,8 @@ public class Tower : MonoBehaviour
         }
     }
 
+
+    // Methods to set or get the missile count
     public int getMissileCount()
     {
         return this.missileCount;

--- a/Seasons Defense/Assets/Scripts/TowerDecider.cs
+++ b/Seasons Defense/Assets/Scripts/TowerDecider.cs
@@ -10,17 +10,29 @@ public class TowerDecider : MonoBehaviour
 
     private void Update()
     {
-        
         if(Input.GetMouseButtonDown(0))
         {
             float xPosOnClick = Input.mousePosition.x;
 
-            //TODO: Add more logic to this algorithm to decide the next best turret to use,
-            //      if the current one has no missiles left
+            if (xPosOnClick < _third) TowerToShoot(leftTower, middleTower, rightTower);
+            else if (xPosOnClick > _third && xPosOnClick < (_third * 2f)) TowerToShoot(middleTower, leftTower, rightTower);
+            else TowerToShoot(rightTower, middleTower, leftTower);
+        }
+    }
 
-            if (xPosOnClick < _third) leftTower.Fire();
-            else if (xPosOnClick > _third && xPosOnClick < (_third * 2f)) middleTower.Fire();
-            else rightTower.Fire();
+    public void TowerToShoot(Tower optimal, Tower secondChoice, Tower lastChoice)
+    {
+        if(optimal.getMissileCount() > 0)
+        {
+            optimal.Fire();
+        }
+        else if(secondChoice.getMissileCount() > 0)
+        {
+            secondChoice.Fire();
+        }
+        else if(lastChoice.getMissileCount() > 0)
+        {
+            lastChoice.Fire();
         }
     }
 

--- a/Seasons Defense/Assets/Scripts/TowerDecider.cs
+++ b/Seasons Defense/Assets/Scripts/TowerDecider.cs
@@ -22,6 +22,8 @@ public class TowerDecider : MonoBehaviour
 
     public void TowerToShoot(Tower optimal, Tower secondChoice, Tower lastChoice)
     {
+        // This can be more complex, but for the time being it works.
+
         if(optimal.getMissileCount() > 0)
         {
             optimal.Fire();


### PR DESCRIPTION
Changes in this PR:
 - Tower.cs 
 - TowerDecider.cs
 - A new Scene (for me to develop) 😄 
 
 The tower script now has a missile count variable that is responsible on whether a tower is allowed to fire a missile. Therefore, if missile count is 0, then the tower won't be allowed to fire. Furthermore, added two simple methods that get and set the missile count value. (Was thinking that if a tower is hit or destroyed, we can simply set its missile count to 0, leaving it useless to the player 😮 )
 
 The tower decider now has very simple logic on what the next tower should fire, if the optimal tower to shoot is out of ammo. (Should I just change the variable name to ammo, or keep it as it is? )
 
 Also, Fixed the missile explosion so that it happens at the target of the missile, not the center of the screen 👍🏼 

