### PR TITLE
Enemy scores

### DIFF
--- a/Seasons Defense/Assets/Prefabs/EnemyMIssile.prefab
+++ b/Seasons Defense/Assets/Prefabs/EnemyMIssile.prefab
@@ -121,3 +121,4 @@ MonoBehaviour:
   explosionPrefab: {fileID: 3727858198622731275, guid: 2f7668d8cd54a6b489d7598ad514ac64, type: 3}
   target: {x: 0, y: 0, z: 0}
   speed: 2
+  worth: 25

--- a/Seasons Defense/Assets/Prefabs/Missile.prefab
+++ b/Seasons Defense/Assets/Prefabs/Missile.prefab
@@ -15,7 +15,7 @@ GameObject:
   - component: {fileID: 3112465313629762751}
   m_Layer: 0
   m_Name: Missile
-  m_TagString: Untagged
+  m_TagString: Player
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -121,3 +121,4 @@ MonoBehaviour:
   explosionPrefab: {fileID: 3727858198622731275, guid: 2f7668d8cd54a6b489d7598ad514ac64, type: 3}
   target: {x: 0, y: 0, z: 0}
   speed: 7
+  worth: 0

--- a/Seasons Defense/Assets/Scripts/Enemy.cs
+++ b/Seasons Defense/Assets/Scripts/Enemy.cs
@@ -8,8 +8,9 @@ public class Enemy : MonoBehaviour
 
     //Delay how fast the missiles Spawn
     public float delayMissileSpawn = 5f;
-
     public int enemyMissileCount = 3;
+
+    public int worth = 100;
     void Start()
     {
         StartCoroutine(SpawnEnemyMissile());
@@ -30,8 +31,11 @@ public class Enemy : MonoBehaviour
     // todo: add particle effects and/or animations to this method
     public void BeingDestroyed()
     {
+        ScoreManager.Instance.AddPoints(worth);
+        
         LevelManager.EnemiesCount--;
         LevelManager.EnemyDestroyed();
+        
         Destroy(gameObject);
     }
 }

--- a/Seasons Defense/Assets/Scripts/Missile.cs
+++ b/Seasons Defense/Assets/Scripts/Missile.cs
@@ -9,6 +9,9 @@ public class Missile : MonoBehaviour
     [HideInInspector]
     public Vector3 target;
     public int speed = 5;
+
+    // This worth is changed for the Enemy Missile prefab
+    public int worth = 0;
     
     private void Start()
     {
@@ -42,8 +45,11 @@ public class Missile : MonoBehaviour
     // method called when a missile destroys this missile object
     public void BeingDestroyed()
     {
+        ScoreManager.Instance.AddPoints(worth);
+        
         LevelManager.EnemyMissileCount--;
         LevelManager.EnemyDestroyed();
+        
         Explode();
     }
 }

--- a/Seasons Defense/Assets/Scripts/Missile.cs
+++ b/Seasons Defense/Assets/Scripts/Missile.cs
@@ -45,6 +45,9 @@ public class Missile : MonoBehaviour
     // method called when a missile destroys this missile object
     public void BeingDestroyed()
     {
+        // In case of an enemy missile exploding a player's missile, we don't assign points or imply enemy destruction
+        if (CompareTag("Player")) return;
+        
         ScoreManager.Instance.AddPoints(worth);
         
         LevelManager.EnemyMissileCount--;

--- a/Seasons Defense/Assets/Scripts/ScoreManager.cs
+++ b/Seasons Defense/Assets/Scripts/ScoreManager.cs
@@ -6,33 +6,31 @@ using TMPro;
 
 public class ScoreManager : MonoBehaviour
 {
-    public static ScoreManager instance;
+    public static ScoreManager Instance;
     
     public TextMeshProUGUI scoreText;
     public TextMeshProUGUI highScoreText;
 
-    int score = 0;
-    int highscore = 0;
+    private int _score = 0;
 
     private void Awake()
     {
-        instance = this;
+        Instance = this;
     }
 
     void Start()
     {
-        highscore = PlayerPrefs.GetInt("highscore", 0);
-        scoreText.text = "SCORE: " + score.ToString();
-        highScoreText.text = "HIGHSCORE: " + highscore.ToString();
+        scoreText.text = "SCORE: " + _score;
+        highScoreText.text = "HIGHSCORE: " + PlayerPrefs.GetInt("HighScore", 0);
     }
 
     public void AddPoints(int points)
     {
-        score += points;
-        scoreText.text = "SCORE: " + score.ToString();
-        if (highscore < score)
+        _score += points;
+        scoreText.text = "SCORE: " + _score;
+        if (PlayerPrefs.GetInt("HighScore", 0) < _score)
         {
-            PlayerPrefs.SetInt("highscore", score);
+            PlayerPrefs.SetInt("HighScore", _score);
         }
     }
 }


### PR DESCRIPTION
This PR will add the functionality of player missiles' destruction of enemies and enemy missiles providing score to the player. The ScoreManager was reformatted to avoid redundant assignment and prevent the high score not being properly Set under PlayerPrefs.